### PR TITLE
Fix stop times incorrect format 

### DIFF
--- a/gtfs.rb
+++ b/gtfs.rb
@@ -160,19 +160,19 @@ class GovRoGTFSConverter
                     time_add_1_DAY = true
                 end
             end
-            stop_data['arrival_time'] = self::seconds_to_hhmm(stop_data['stop_arrival_seconds'], time_add_1_DAY)
+            stop_data['arrival_time'] = self::seconds_to_string(stop_data['stop_arrival_seconds'], time_add_1_DAY)
 
 
             if time_add_1_DAY.nil? && is_not_last_stop && (stop_data['stop_arrival_seconds'] > stop_data['stop_departure_seconds'])
                 time_add_1_DAY = true
             end
-            stop_data['departure_time'] = self::seconds_to_hhmm(stop_data['stop_departure_seconds'], time_add_1_DAY)
+            stop_data['departure_time'] = self::seconds_to_string(stop_data['stop_departure_seconds'], time_add_1_DAY)
         end
 
         return trip_stop_rows
     end
 
-    def self.seconds_to_hhmm(total_seconds, add_one_day)
+    def self.seconds_to_string(total_seconds, add_one_day)
         if total_seconds == -1
             return nil
         end
@@ -185,8 +185,7 @@ class GovRoGTFSConverter
         minutes = (total_seconds / 60) % 60
         hours = total_seconds / (60 * 60)
     
-        hhmm = format("%02d:%02d", hours, minutes)
-        return hhmm
+        return format("%02d:%02d:%02d", hours, minutes, seconds)
     end
 
     def self.gtfs_data_agency


### PR DESCRIPTION
As mentioned in issue #1 , the correct format for the time is eight digits , as per the GTFS specification documentation available at https://developers.google.com/transit/gtfs/reference#stop_timestxt

```
Times must be eight digits in HH:MM:SS format (H:MM:SS is also accepted, if the hour begins with 0). 
Do not pad times with spaces.   

The following columns list stop times for a trip and the proper way to express those times in the arrival_time field:
Time    arrival_time value
08:10:00 A.M.   08:10:00 or 8:10:00
01:05:00 P.M.   13:05:00
07:40:00 P.M.   19:40:00
01:55:00 A.M.   25:55:00
```
